### PR TITLE
support hyper-schema and regular schema

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -34,18 +34,15 @@ func clean(gen []byte) ([]byte, error) {
 
 func (s *Schema) Generate() ([]byte, error) {
 	// Default to hyper schema for backwards compatibility
-	if s.Schema == nil || *s.Schema == "" {
+	if s.Schema == nil {
 		return s.generateHyperSchema()
 	}
 	switch *s.Schema {
 	case "http://json-schema.org/schema#", "http://json-schema.org/draft-04/schema#",
 		"http://json-schema.org/draft-03/schema#":
 		return s.generateSchema()
-	case "http://json-schema.org/hyper-schema#", "http://json-schema.org/draft-04/hyper-schema#",
-		"http://json-schema.org/draft-03/hyper-schema#":
-		return s.generateHyperSchema()
 	}
-	return nil, fmt.Errorf("unknown $schema keyword %s", *s.Schema)
+	return s.generateHyperSchema()
 }
 
 func (s *Schema) generateSchema() ([]byte, error) {

--- a/helpers.go
+++ b/helpers.go
@@ -48,7 +48,12 @@ func required(n string, def *Schema) bool {
 }
 
 func fieldTag(n string, required bool) string {
-	return fmt.Sprintf("`%s %s`", jsonTag(n, required), urlTag(n, required))
+	tags := []string{jsonTag(n, required), urlTag(n, required), bsonTag(n, required)}
+	return fmt.Sprintf("`%s`", strings.Join(tags, " "))
+}
+
+func formatTag(n string, v []string) string {
+	return fmt.Sprintf(`%s:"%s"`, n, strings.Join(v, ","))
 }
 
 func jsonTag(n string, required bool) string {
@@ -56,7 +61,15 @@ func jsonTag(n string, required bool) string {
 	if !required {
 		tags = append(tags, "omitempty")
 	}
-	return fmt.Sprintf("json:\"%s\"", strings.Join(tags, ","))
+	return formatTag("json", tags)
+}
+
+func bsonTag(n string, required bool) string {
+	tags := []string{n}
+	if !required {
+		tags = append(tags, "omitempty")
+	}
+	return formatTag("bson", tags)
 }
 
 func urlTag(n string, required bool) string {
@@ -65,7 +78,7 @@ func urlTag(n string, required bool) string {
 		tags = append(tags, "omitempty")
 	}
 	tags = append(tags, "key")
-	return fmt.Sprintf("url:\"%s\"", strings.Join(tags, ","))
+	return formatTag("url", tags)
 }
 
 func contains(n string, r []string) bool {

--- a/templates/hyperpackage.tmpl
+++ b/templates/hyperpackage.tmpl
@@ -1,0 +1,11 @@
+// Generated service client for {{.}} API.
+//
+// To be able to interact with this API, you have to
+// create a new service:
+//
+//     s := {{.}}.NewService(nil)
+//
+// The Service struct has all the methods you need
+// to interact with {{.}} API.
+//
+package {{.}}

--- a/templates/package.tmpl
+++ b/templates/package.tmpl
@@ -1,11 +1,2 @@
-// Generated service client for {{.}} API.
-//
-// To be able to interact with this API, you have to
-// create a new service:
-//
-//     s := {{.}}.NewService(nil)
-//
-// The Service struct has all the methods you need
-// to interact with {{.}} API.
-//
+// Generated type definition for {{.}}
 package {{.}}

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -38,7 +38,7 @@ var templates = map[string]string{"field.tmpl": `{{initialCap .Name}} {{.Type}} 
     )
   {{end}}
 {{end}}`,
-	"package.tmpl": `// Generated service client for {{.}} API.
+	"hyperpackage.tmpl": `// Generated service client for {{.}} API.
 //
 // To be able to interact with this API, you have to
 // create a new service:
@@ -48,6 +48,9 @@ var templates = map[string]string{"field.tmpl": `{{initialCap .Name}} {{.Type}} 
 // The Service struct has all the methods you need
 // to interact with {{.}} API.
 //
+package {{.}}
+`,
+	"package.tmpl": `// Generated type definition for {{.}}
 package {{.}}
 `,
 	"service.tmpl": `const (


### PR DESCRIPTION
Currently, `schematic` only supports creating API clients for JSON hyper-schema. We'd like to use it to create Go types from JSON schema for other purposes, too (example: maintaining database schemas in JSONSchema for use across multiple languages).

This makes `schematic` detect the schema type based on the `$schema` property and generate only Go types if it's not hyper-schema.
